### PR TITLE
add ignore, prob rule for mats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.aux
+*.bbl
+*.gz
+*.fls
+*.log
+*.fdb_latexmk

--- a/linalg_cheatsheet.tex
+++ b/linalg_cheatsheet.tex
@@ -186,6 +186,15 @@
 		\end{align}
 	\end{minipage}
 
+	\subsection{Matrix Tricks}
+
+	\textbf{Probability Rules for Matrices:}
+
+	• Pull Matrix Multiply out of Variance:
+	$$
+		Var[Mx] = MVar[x]M^T
+	$$
+
 	\subsection{Eigenvalues and Eigenvectors}
 
 	\begin{empheq}[box = \mathboxnoback]{align*}
@@ -291,6 +300,7 @@
 	$$
 		H(L) = 2\mathbf{X}^T\mathbf{X}
 	$$
+
 
 	\subsubsection{Logistic Regression Loss}{}
 


### PR DESCRIPTION
Added a .gitignore, and a probability rule useful for variance cals with matrix transforms